### PR TITLE
Issue 13 - ci(devenv.nix): added pinentry to the devenv

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -4,6 +4,7 @@
     [
       git
       gnupg
+      pinentry-curses
       git-cliff
       commitizen
 
@@ -14,9 +15,7 @@
       markdownlint-cli
       nixfmt-rfc-style
     ]
-    ++ (with nodePackages; [
-      vercel
-    ]);
+    ++ (with nodePackages; [vercel]);
 
   languages.javascript = {
     enable = true;


### PR DESCRIPTION
weird error with `pinentry-all`...but the curses version is ok?
Fixes #13