### PR TITLE
fix(devenv.nix): fixed eslint filetype checker

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -54,6 +54,12 @@
 
     # HTML, CSS, JS, TS, etc.
     prettier.enable = true;
-    eslint.enable = true;
+    eslint = {
+      enable = true;
+      args = ["--fix app/"];
+      settings = {
+        extensions = "\.(js|jsx|ts|tsx|mdx)$";
+      };
+    };
   };
 }


### PR DESCRIPTION
only ran on js, but now wider range

Closes #18 