### PR TITLE
fix(components/header.tsx): using the pathname instead of a state hook

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { usePathname } from "next/navigation";
 import { CiCircleChevUp } from "react-icons/ci";
 
 // Define the header elements as well as the root path and label
@@ -18,7 +18,7 @@ const headers = {
 const imageSize = 28;
 
 export default function Header() {
-  const [activeHeader, setActiveHeader] = useState(headers.home.root);
+  const pathname = usePathname();
 
   return (
     <header>
@@ -42,15 +42,12 @@ export default function Header() {
               <div className="flex flex-col items-center">
                 <Link
                   href={`${value.root}`}
-                  onClick={() => {
-                    setActiveHeader(value.root);
-                  }}
                   className="hover:underline hover:underline-offset-4"
                 >
                   {value.label}
                 </Link>
                 <CiCircleChevUp
-                  className={`${activeHeader === value.root ? "block" : "hidden"}`}
+                  className={`${pathname === value.root ? "block" : "hidden"}`}
                 />
               </div>
             </li>


### PR DESCRIPTION
reads from the URL so that refreshes don't wipe the state

Closes #57