### PR TITLE
fix: added brackets around the git email

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -56,7 +56,7 @@ jobs:
           branch: bump-version-${{ steps.cz.outputs.version }}
           title: Bump version ${{ steps.cz.outputs.version }}
           committer:
-            "${{ steps.gpg.outputs.name }} ${{  steps.gpg.outputs.email }}"
+            "${{ steps.gpg.outputs.name }} <${{ steps.gpg.outputs.email }}>"
       # add tag manually, since the PR action does not push tags
       - run: |
           git push origin --tags


### PR DESCRIPTION
can't create username without the tags apparently...

Closes #20 