### PR TITLE
fix: remove signed push from gpg step

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -32,7 +32,6 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
           git_commit_gpgsign: true
           git_tag_gpgsign: true
-          git_push_gpgsign: true
           git_config_global: true
           trust_level: 5
 


### PR DESCRIPTION
github does not support signed pushes!

Closes #20 